### PR TITLE
Revert to work with flutter < v3.21

### DIFF
--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -17,14 +17,14 @@ class IconProperty {
 class CheckBoxProperty {
   final MouseCursor? mouseCursor;
   final Color? activeColor;
-  final WidgetStateProperty<Color?>? fillColor;
+  final MaterialStateProperty<Color?>? fillColor;
   final Color? checkColor;
   final bool tristate;
   final MaterialTapTargetSize? materialTapTargetSize;
   final VisualDensity? visualDensity;
   final Color? focusColor;
   final Color? hoverColor;
-  final WidgetStateProperty<Color?>? overlayColor;
+  final MaterialStateProperty<Color?>? overlayColor;
   final double? splashRadius;
   final FocusNode? focusNode;
   final bool autofocus;


### PR DESCRIPTION
Flutter v3.21 had breaking changes https://docs.flutter.dev/release/breaking-changes/material-state

This temporarily reverts the package to still function with flutter < v3.21