### PR TITLE
Fix up render bug for overlayKey.currentContext not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+- 'WidgetStateProperty' not found - fixed
+
 ## 1.1.0
 - Deprecated bug fixes
 - README updated

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -173,6 +173,8 @@ class _TestPageState extends State<TestPage> {
                   controller: _cntMulti,
                   // initialValue: const ["name1", "name2", "name8", "name3"],
                   // displayCompleteItem: true,
+                  checkBoxProperty: CheckBoxProperty(
+                      fillColor: MaterialStateProperty.all<Color>(Colors.red)),
                   dropDownList: const [
                     DropDownValueModel(name: 'name1', value: "value1"),
                     DropDownValueModel(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   equatable:
     dependency: transitive
     description:

--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -17,14 +17,14 @@ class IconProperty {
 class CheckBoxProperty {
   final MouseCursor? mouseCursor;
   final Color? activeColor;
-  final WidgetStateProperty<Color?>? fillColor;
+  final MaterialStateProperty<Color?>? fillColor;
   final Color? checkColor;
   final bool tristate;
   final MaterialTapTargetSize? materialTapTargetSize;
   final VisualDensity? visualDensity;
   final Color? focusColor;
   final Color? hoverColor;
-  final WidgetStateProperty<Color?>? overlayColor;
+  final MaterialStateProperty<Color?>? overlayColor;
   final double? splashRadius;
   final FocusNode? focusNode;
   final bool autofocus;

--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -557,19 +557,21 @@ class _DropDownTextFieldState extends State<DropDownTextField>
             enabled: widget.isEnabled,
             readOnly: widget.readOnly,
             onTapOutside: (event) {
-              final RenderBox renderBox =
-                  overlayKey.currentContext?.findRenderObject() as RenderBox;
-              final overlayPosition = renderBox.localToGlobal(Offset.zero);
-              final overlaySize = renderBox.size;
-              bool isOverlayTap = (overlayPosition.dx <= event.position.dx &&
-                      event.position.dx <=
-                          overlayPosition.dx + overlaySize.width) &&
-                  (overlayPosition.dy <= event.position.dy &&
-                      event.position.dy <=
-                          overlayPosition.dy + overlaySize.height);
+              if (overlayKey.currentContext != null) {
+                final RenderBox renderBox =
+                    overlayKey.currentContext?.findRenderObject() as RenderBox;
+                final overlayPosition = renderBox.localToGlobal(Offset.zero);
+                final overlaySize = renderBox.size;
+                bool isOverlayTap = (overlayPosition.dx <= event.position.dx &&
+                        event.position.dx <=
+                            overlayPosition.dx + overlaySize.width) &&
+                    (overlayPosition.dy <= event.position.dy &&
+                        event.position.dy <=
+                            overlayPosition.dy + overlaySize.height);
 
-              if (!isOverlayTap) {
-                _textFieldFocusNode.unfocus();
+                if (!isOverlayTap) {
+                  _textFieldFocusNode.unfocus();
+                }
               }
             },
             onTap: () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dropdown_textfield
 description: A DropdownTextfield is a material design TextField. The DropDownButton is a widget that we can use to select one unique value or multivalue from a set of values.
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/srtraj/dropdown_textfield
 
 environment:


### PR DESCRIPTION
When navigating to a page with a dropdown field, sometimes the current context isn't setup correctly when the drop down tries to unfocus the search text node, causing an application crash.  This fixes the bug to check for null before unfocussing the ext field.